### PR TITLE
Add option to disable log file output

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: VennDiagram
-Version: 1.6.22
+Version: 1.6.23
 Type: Package
 Title: Generate High-Resolution Venn and Euler Plots
-Date: 2018-06-04
+Date: 2021-08-27
 Author: Hanbo Chen
 Maintainer: Paul Boutros <Paul.Boutros@oicr.on.ca>
 Depends: R (>= 2.14.1), grid (>= 2.14.1), futile.logger

--- a/NEWS
+++ b/NEWS
@@ -1,4 +1,4 @@
-VennDiagram 1.6.22 2021-08-27 (Dan Knight)
+VennDiagram 1.6.23 2021-08-27 (Dan Knight)
 ---------------------------------------------------------------------------------------------------
 MINOR UPDATES
 * Added option to disable .log file output and print to console instead

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+VennDiagram 1.6.22 2021-08-27 (Dan Knight)
+---------------------------------------------------------------------------------------------------
+MINOR UPDATES
+* Added option to disable .log file output and print to console instead
+
 VennDiagram 1.6.22 2018-08-13 (Christopher Lalansingh)
 ---------------------------------------------------------------------------------------------------
 MINOR UPDATES

--- a/R/venn.diagram.R
+++ b/R/venn.diagram.R
@@ -13,6 +13,7 @@
 venn.diagram <- function(
 	x,
 	filename,
+	disable.logging = FALSE,
 	height = 3000,
 	width = 3000,
 	resolution = 500,
@@ -50,12 +51,14 @@ venn.diagram <- function(
 	time.string = gsub(":", "-", gsub(" ", "_", as.character(Sys.time())))
 	
 	#Initialize the logger to output to file
-	if(!is.null(filename)){
-		flog.appender(appender.file(paste0(filename,".",time.string,".log")), name='VennDiagramLogger')
-	}
-	else{
-		flog.appender(appender.file(paste0("VennDiagram",time.string,".log")), name='VennDiagramLogger')
-	}
+	if (disable.logging) {
+	    flog.appender(appender.console(), name = 'VennDiagramLogger');
+    	} else {
+    	    flog.appender(appender.file(
+    	        paste0(if (!is.null(filename)) filename else 'VennDiagram', '.', time.string, '.log')),
+    	        name = 'VennDiagramLogger'
+    	    );
+    	}
 	
 	#Log the parameters the function was called with
 	out.list = as.list(sys.call())

--- a/man/venn.diagram.Rd
+++ b/man/venn.diagram.Rd
@@ -4,10 +4,10 @@
 \description{This function takes a list and creates a publication-quality TIFF Venn 
 Diagram}
 \usage{
-venn.diagram(x, filename, disable.logging = FALSE, height = 3000, width = 3000, 
-    resolution = , imagetype = "tiff", units = "px", compression =
-    "lzw", na = "stop", main = NULL, sub = NULL, main.pos
-    = c(0.5, 1.05), main.fontface = "plain",
+venn.diagram(x, filename, disable.logging = FALSE, height = 3000, 
+    width = 3000, resolution = 500, imagetype = "tiff", 
+    units = "px", compression = "lzw", na = "stop", main = NULL, 
+    sub = NULL, main.pos = c(0.5, 1.05), main.fontface = "plain",
     main.fontfamily = "serif", main.col = "black",
     main.cex = 1, main.just = c(0.5, 1), sub.pos = c(0.5,
     1.05), sub.fontface = "plain", sub.fontfamily =

--- a/man/venn.diagram.Rd
+++ b/man/venn.diagram.Rd
@@ -4,8 +4,8 @@
 \description{This function takes a list and creates a publication-quality TIFF Venn 
 Diagram}
 \usage{
-venn.diagram(x, filename, height = 3000, width = 3000, resolution =
-    500, imagetype = "tiff", units = "px", compression =
+venn.diagram(x, filename, disable.logging = FALSE, height = 3000, width = 3000, 
+    resolution = , imagetype = "tiff", units = "px", compression =
     "lzw", na = "stop", main = NULL, sub = NULL, main.pos
     = c(0.5, 1.05), main.fontface = "plain",
     main.fontfamily = "serif", main.col = "black",
@@ -21,6 +21,7 @@ venn.diagram(x, filename, height = 3000, width = 3000, resolution =
   \item{x}{A list of vectors (e.g., integers, chars), with each component corresponding 
   to a separate circle in the Venn diagram}
   \item{filename}{Filename for image output, or if NULL returns the grid object itself}
+  \item{disable.logging}{Boolean to disable log file output and print to console instead}
   \item{height}{Integer giving the height of the output figure in units}
   \item{width}{Integer giving the width of the output figure in units}
   \item{resolution}{Resolution of the final figure in DPI}

--- a/tests/testthat/test-Log.R
+++ b/tests/testthat/test-Log.R
@@ -1,0 +1,19 @@
+#Testing using package testthat for detailed error messages
+library(testthat)
+
+#load in the reference plot data
+load('data/plotsOne.rda');
+
+#Suppress plotting for sanity
+options(device = pdf());
+
+disabled.output <- capture_output(
+    venn.diagram(list(A = 1:20, B = 11:30), filename = NULL, disable.logging = TRUE)
+    );
+
+test_that(
+    'Disabled log file export',
+    expect_gt(nchar(disabled.output), 0)
+    );
+    
+print('Logging tests complete. No discrepancies found');

--- a/tests/testthat/test-Log.R
+++ b/tests/testthat/test-Log.R
@@ -1,19 +1,19 @@
 #Testing using package testthat for detailed error messages
 library(testthat)
 
-#load in the reference plot data
-load('data/plotsOne.rda');
-
 #Suppress plotting for sanity
 options(device = pdf());
 
-disabled.output <- capture_output(
-    venn.diagram(list(A = 1:20, B = 11:30), filename = NULL, disable.logging = TRUE)
-    );
-
 test_that(
-    'Disabled log file export',
-    expect_gt(nchar(disabled.output), 0)
+    'Disabled log file export', {
+        disabled.output <- capture_output(
+            venn.diagram(
+                list(A = 1:20, B = 11:30),
+                filename = NULL,
+                disable.logging = TRUE
+                )
+            );
+        
+        expect_gt(nchar(disabled.output), 0);
+        }
     );
-    
-print('Logging tests complete. No discrepancies found');


### PR DESCRIPTION
If disabled, futile.logger will print all logged info and errors to the console instead. Also added a test case to verify the console output.