### PR TITLE
Bump R-CMD-check-action to v2

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,24 +1,18 @@
 ---
-name: R-CMD-check
-
+name: R CMD check
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
   pull_request:
     branches:
       - main
-
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "0 0 * * MON"
 jobs:
   R-CMD-check:
     runs-on: ubuntu-latest
-
-    container:
-      image: blcdsdockerregistry/bl-r-devel:latest
-
     steps:
-      - uses: actions/checkout@v2
-        with:
-          path: VennDiagram
-      - run: R CMD build --compact-vignettes="gs+qpdf" VennDiagram
-      - run: R CMD check --as-cran --run-donttest VennDiagram_*.tar.gz
+      - uses: r-lib/actions/setup-tinytex@v2
+      - uses: uclahs-cds/tool-R-CMD-check-action@v2


### PR DESCRIPTION
This PR updates inlined workflow steps that run `R CMD check` to use the `R-CMD-check` v2 action.
