### PR TITLE
Fix futile log

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,5 @@
 metadata.yaml
 
 LICENSE.md
+
+^\.cicd-env$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: VennDiagram
-Version: 1.8.0
+Version: 1.8.1
 Type: Package
 Title: Generate High-Resolution Venn and Euler Plots
 Author: Hanbo Chen

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Version: 1.8.1
 Type: Package
 Title: Generate High-Resolution Venn and Euler Plots
 Author: Hanbo Chen
-Maintainer: Paul Boutros <pboutros@mednet.ucla.edu>
+Maintainer: Paul Boutros <pboutros@sbpdiscovery.org>
 Imports:
   methods
 Depends: R (>= 3.5.0), grid (>= 2.14.1), futile.logger

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,6 @@ Package: VennDiagram
 Version: 1.8.0
 Type: Package
 Title: Generate High-Resolution Venn and Euler Plots
-Date: 2025-06-17
 Author: Hanbo Chen
 Maintainer: Paul Boutros <pboutros@mednet.ucla.edu>
 Imports:

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,8 @@
+VennDiagram 1.8.1 2026-01-07 (Rupert Hugh-White)
+---------------------------------------------------------------------------------------------------
+MINOR UPDATES
+* modify unit test for Log to keep compatible with newest futile.logger version
+
 VennDiagram 1.8.0 2025-06-17 (Stefan Eng, Dan Knight, John Sahrmann)
 ---------------------------------------------------------------------------------------------------
 MINOR UPDATES

--- a/NEWS
+++ b/NEWS
@@ -1,7 +1,8 @@
 VennDiagram 1.8.1 2026-01-07 (Rupert Hugh-White)
 ---------------------------------------------------------------------------------------------------
 MINOR UPDATES
-* modify unit test for Log to keep compatible with newest futile.logger version
+* Modify unit test for Log to keep compatible with newest futile.logger version
+* Update maintainer's email address
 
 VennDiagram 1.8.0 2025-06-17 (Stefan Eng, Dan Knight, John Sahrmann)
 ---------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or to install the latest development version from Github:
 # If `devtools` is not already installed, run:
 # install.packages("devtools");
 
-devtools::install_github('uclahs-cds/public-R-VennDiagram');
+devtools::install_github('uclahs-cds/package-VennDiagram');
 ```
 
 ## Example plots
@@ -79,19 +79,19 @@ A side-by-side comparison of an Euler diagram and a Venn diagram for the same hy
 
 ## Resources
 
-Available resources for VennDiagram include the package [CRAN page](https://cran.r-project.org/web/packages/VennDiagram/index.html) and [reference manual](https://cran.r-project.org/web/packages/VennDiagram/VennDiagram.pdf).
+Available resources for VennDiagram include the package [CRAN page](https://CRAN.R-project.org/package=VennDiagram) and [reference manual](https://cran.r-project.org/web/packages/VennDiagram/VennDiagram.pdf).
 
 ## Getting help
 
-For guidance or support with VennDiagram check out [Discussions](https://github.com/uclahs-cds/public-R-VennDiagram/discussions)
+For guidance or support with VennDiagram check out [Discussions](https://github.com/uclahs-cds/package-VennDiagram/discussions)
 
-See [Issues](https://github.com/uclahs-cds/public-R-VennDiagram/issues) to submit bugs, suggest new features or view current works
+See [Issues](https://github.com/uclahs-cds/package-VennDiagram/issues) to submit bugs, suggest new features or view current works
 
-[Pull requests](https://github.com/uclahs-cds/public-R-VennDiagram/pulls) are also open for discussion.
+[Pull requests](https://github.com/uclahs-cds/package-VennDiagram/pulls) are also open for discussion.
 
 ## Contributors
 
-Contributors to this package can be viewed [here](https://github.com/uclahs-cds/public-R-VennDiagram/graphs/contributors) on GitHub.
+Contributors to this package can be viewed [here](https://github.com/uclahs-cds/package-VennDiagram/graphs/contributors) on GitHub.
 
 ## Citation information
 

--- a/tests/testthat/test-Log.R
+++ b/tests/testthat/test-Log.R
@@ -12,7 +12,7 @@ test_that(
                 filename = NULL,
                 disable.logging = TRUE
                 )
-            )    
+            )
         expect_gt(nchar(paste(disabled.output, collapse = "\n")), 0)
         }
     );

--- a/tests/testthat/test-Log.R
+++ b/tests/testthat/test-Log.R
@@ -6,14 +6,13 @@ options(device = pdf(file = NULL));
 
 test_that(
     'Disabled log file export', {
-        disabled.output <- capture_output(
+        disabled.output <- capture_messages(
             venn.diagram(
                 list(A = 1:20, B = 11:30),
                 filename = NULL,
                 disable.logging = TRUE
                 )
-            );
-        
-        expect_gt(nchar(disabled.output), 0);
+            )    
+        expect_gt(nchar(paste(disabled.output, collapse = "\n")), 0)
         }
     );


### PR DESCRIPTION
# Description
<!--- Briefly describe the changes included in this pull request  --->
Fixing a compatability issue with the latest version of dependency futile.logger.
From [https://cran.r-project.org/web/checks/check_results_VennDiagram.html](https://cran.r-project.org/web/checks/check_results_VennDiagram.html):

```
>Version: 1.7.3
Check: tests
Result: ERROR 
    Running ‘test-all.R’ [7s/9s]
  Running the tests in ‘tests/test-all.R’ failed.
  Complete output:
    > library(testthat);
    > library(VennDiagram);
    Loading required package: grid
    Loading required package: futile.logger
    > test_check('VennDiagram');#This should only be used in /tests/test-all.R, and is run by R CMD check
    Saving _problems/test-Log-17.R
    [ FAIL 1 | WARN 0 | SKIP 1 | PASS 391 ]
    
    ══ Skipped tests (1) ═══════════════════════════════════════════════════════════
    • empty test (1):
    
    ══ Failed tests ════════════════════════════════════════════════════════════════
    ── Failure ('test-Log.R:17:9'): Disabled log file export ───────────────────────
    Expected `nchar(disabled.output)` > 0.
    Actual comparison: 0.0 <= 0.0
    Difference: 0.0 <= 0
    
    [ FAIL 1 | WARN 0 | SKIP 1 | PASS 391 ]
    Error:
    ! Test failures.
    Execution halted
```

# Changes

1. small patch to fix compatability issue
2. modify URLs to reduce CRAN check NOTES
3. update maintainer email
4. increment version and NEWS

Unit test now passes:

```
testthat::test_file('tests/testthat/test-Log.R')

══ Testing test-Log.R ═══════════════════════════════════════════════════════════════════════════════════════════════
[ FAIL 0 | WARN 0 | SKIP 0 | PASS 1 ] Done!
```

CRAN check passes without error/warning
`R CMD check --as-cran VennDiagram_1.8.1.tar.gz`
`Status: 3 NOTEs`
